### PR TITLE
Don't extract 9500 doc files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,7 @@ RUN apk --update add --virtual builddeps \
   && rm -rf /var/cache/apk/*
 
 #Install HBase and scripts
-RUN mkdir -p /data/hbase /root/.profile.d /opt/downloads
-
-WORKDIR /opt/downloads
+RUN mkdir -p /data/hbase /root/.profile.d
 RUN curl -s -o - \
     http://archive.apache.org/dist/hbase/${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz | tar xzf - --exclude=docs \
   && mv hbase-${HBASE_VERSION} /opt/hbase

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN mkdir -p /data/hbase /root/.profile.d /opt/downloads
 
 WORKDIR /opt/downloads
 RUN curl -s -o - \
-    http://archive.apache.org/dist/hbase/${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz | tar xzf - \
+    http://archive.apache.org/dist/hbase/${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz | tar xzf - --exclude=docs \
   && mv hbase-${HBASE_VERSION} /opt/hbase
 
 ADD docker/hbase-site.xml /opt/hbase/conf/


### PR DESCRIPTION
The hbase archive contains a docs folder with ~9500 files that are ~267MB in size. Since they are not needed, don't extract them.